### PR TITLE
Refer to correct type in rustdoc

### DIFF
--- a/src/sync/boxed.rs
+++ b/src/sync/boxed.rs
@@ -26,7 +26,7 @@ impl<Y, R, C> GenBoxed<Y, R, C> {
     /// #     for n in (1..).step_by(2).take_while(|&n| n < 10) { co.yield_(n).await; }
     /// # }
     /// #
-    /// let _: GenBoxed<i32> = Gen::new_boxed(|co| producer(co));
+    /// let _: GenBoxed<i32> = GenBoxed::new_boxed(|co| producer(co));
     /// let _: GenBoxed<i32> = Gen::new(|co| Box::pin(producer(co)));
     /// ```
     pub fn new_boxed<F>(producer: impl FnOnce(Co<Y, R>) -> F) -> Self


### PR DESCRIPTION
The `new_boxed` method lives on the `GenBoxed` type and not on `Gen` as the docs might suggest.

This is only a small fix to make it correct.
While doing it, I thought that actually, it might be better to move this method onto the `Gen` type.

What do you think?

The type `GenBoxed` could still be in its own module with the tests.