### PR TITLE
add syn features = "full"

### DIFF
--- a/genawaiter-proc-macro/Cargo.toml
+++ b/genawaiter-proc-macro/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-syn = { version = "1.0", features = ["visit-mut"] }
+syn = { version = "1.0", features = ["visit-mut", "full"] }
 proc-macro-error = "0.4"
 proc-macro-hack = "0.5"
 


### PR DESCRIPTION
fixes #12 

This was working for all tests because of `futures-macro` a dep of `futures` has `syn = { version = "", features = ["full"] }