### PR TITLE
Make `Co::yield_` take &mut self

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "genawaiter-proc-macro 0.99.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trybuild 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -108,6 +109,21 @@ dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -190,6 +206,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,8 +264,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
@@ -229,6 +334,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
 "checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
@@ -239,7 +347,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rustversion 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c48f91977f4ef3be5358c15d131d3f663f6b4d7a112555bf3bf52ad23b6659e5"
+"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+"checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd3937748a7eccff61ba5b90af1a20dbf610858923a9192ea0ecb0cb77db1d0"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+"checksum trybuild 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "26ff1b18659a2218332848d76ad1c867ce4c6ee37b085e6bc8de9a6d11401220"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = ["genawaiter-macro", "genawaiter-proc-macro"]
 [dev-dependencies]
 futures = "0.3.1"
 once_cell = "1.3.1"
+trybuild = "1"
 
 [features]
 default = ["proc_macro"]

--- a/genawaiter-proc-macro/src/lib.rs
+++ b/genawaiter-proc-macro/src/lib.rs
@@ -127,19 +127,22 @@ pub fn rc_producer(input: TokenStream) -> TokenStream {
 
 mod stack {
     pub(crate) const CO_ARG_FN: &str =
-        "__private_co_arg__: ::genawaiter::stack::Co<'_, ";
+        "mut __private_co_arg__: ::genawaiter::stack::Co<'_, ";
     pub(crate) const CO_ARG: &str =
-        "__private_co_arg__: ::genawaiter::stack::Co<'_, _, _>";
+        "mut __private_co_arg__: ::genawaiter::stack::Co<'_, _, _>";
 }
 
 mod sync {
-    pub(crate) const CO_ARG_FN: &str = "__private_co_arg__: ::genawaiter::sync::Co<";
-    pub(crate) const CO_ARG: &str = "__private_co_arg__: ::genawaiter::sync::Co<_, _>";
+    pub(crate) const CO_ARG_FN: &str =
+        "mut __private_co_arg__: ::genawaiter::sync::Co<";
+    pub(crate) const CO_ARG: &str =
+        "mut __private_co_arg__: ::genawaiter::sync::Co<_, _>";
 }
 
 mod rc {
-    pub(crate) const CO_ARG_FN: &str = "__private_co_arg__: ::genawaiter::rc::Co<";
-    pub(crate) const CO_ARG: &str = "__private_co_arg__: ::genawaiter::rc::Co<_, _>";
+    pub(crate) const CO_ARG_FN: &str = "mut __private_co_arg__: ::genawaiter::rc::Co<";
+    pub(crate) const CO_ARG: &str =
+        "mut __private_co_arg__: ::genawaiter::rc::Co<_, _>";
 }
 
 /// Mutates the input `Punctuated<FnArg, Comma>` to a lifetimeless `co:

--- a/src/core.rs
+++ b/src/core.rs
@@ -128,7 +128,7 @@ impl<A: Airlock> Co<A> {
     /// The caller should immediately `await` the result of this function.
     ///
     /// [_See the module-level docs for examples._](.)
-    pub fn yield_(&self, value: A::Yield) -> impl Future<Output = A::Resume> + '_ {
+    pub fn yield_(&mut self, value: A::Yield) -> impl Future<Output = A::Resume> + '_ {
         #[cfg(debug_assertions)]
         match self.airlock.peek() {
             Next::Yield(()) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ use the low-level API directly:
 ```rust
 # use genawaiter::sync::{Co, Gen};
 #
-let count_to_ten = Gen::new(|co| async move {
+let count_to_ten = Gen::new(|mut co| async move {
     for n in 0..10 {
         co.yield_(n).await;
     }

--- a/src/rc/iterator.rs
+++ b/src/rc/iterator.rs
@@ -31,7 +31,7 @@ mod tests {
     use crate::rc::{Co, Gen};
     use std::iter::IntoIterator;
 
-    async fn produce(co: Co<i32>) {
+    async fn produce(mut co: Co<i32>) {
         co.yield_(10).await;
         co.yield_(20).await;
     }

--- a/src/rc/nightly_tests.rs
+++ b/src/rc/nightly_tests.rs
@@ -5,7 +5,7 @@ use crate::{ops::GeneratorState, rc::Gen};
 
 #[test]
 fn async_closure() {
-    let mut gen = Gen::new(async move |co| {
+    let mut gen = Gen::new(async move |mut co| {
         co.yield_(10).await;
         "done"
     });

--- a/src/rc/stream.rs
+++ b/src/rc/stream.rs
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn blocking() {
-        async fn produce(co: Co<i32>) {
+        async fn produce(mut co: Co<i32>) {
             co.yield_(10).await;
             co.yield_(20).await;
         }
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn non_blocking() {
-        async fn produce(co: Co<i32>) {
+        async fn produce(mut co: Co<i32>) {
             SlowFuture::new().await;
             co.yield_(10).await;
             SlowFuture::new().await;

--- a/src/stack/iterator.rs
+++ b/src/stack/iterator.rs
@@ -55,7 +55,7 @@ mod tests {
     use crate::stack::{let_gen_using, Co, Gen, Shelf};
     use std::iter::IntoIterator;
 
-    async fn produce(co: Co<'_, i32>) {
+    async fn produce(mut co: Co<'_, i32>) {
         co.yield_(10).await;
         co.yield_(20).await;
     }

--- a/src/stack/macros.rs
+++ b/src/stack/macros.rs
@@ -52,7 +52,7 @@ mod tests {
         let mut gen = unsafe { Gen::new(&mut shelf, shenanigans) };
 
         // Get the `co` out of the generator (don't try this at home).
-        let escaped_co = match gen.resume() {
+        let mut escaped_co = match gen.resume() {
             GeneratorState::Yielded(_) => panic!(),
             GeneratorState::Complete(co) => co,
         };

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -23,7 +23,7 @@ requires you to trade away safety.
 ```rust
 # use genawaiter::stack::{Co, Gen, Shelf};
 #
-async fn my_producer(co: Co<'_, u8>) {
+async fn my_producer(mut co: Co<'_, u8>) {
     co.yield_(10).await;
 }
 let mut shelf = Shelf::new();
@@ -186,7 +186,7 @@ macros.
 ```rust
 use genawaiter::stack::{let_gen_using, Co};
 
-async fn producer(co: Co<'_, i32>) {
+async fn producer(mut co: Co<'_, i32>) {
     let mut n = 1;
     while n < 10 {
         co.yield_(n).await;
@@ -218,7 +218,7 @@ assert_eq!(gen.resume(), GeneratorState::Complete(()));
 ```
 # use genawaiter::{stack::let_gen_using, GeneratorState};
 #
-let_gen_using!(gen, |co| async move {
+let_gen_using!(gen, |mut co| async move {
     co.yield_(10).await;
     co.yield_(20).await;
 });
@@ -234,7 +234,7 @@ This is just ordinary Rust, nothing special.
 ```rust
 # use genawaiter::{stack::{let_gen_using, Co}, GeneratorState};
 #
-async fn multiples_of(num: i32, co: Co<'_, i32>) {
+async fn multiples_of(num: i32, mut co: Co<'_, i32>) {
     let mut cur = num;
     loop {
         co.yield_(cur).await;
@@ -353,7 +353,7 @@ mod tests {
         },
     };
 
-    async fn simple_producer(co: Co<'_, i32>) -> &'static str {
+    async fn simple_producer(mut co: Co<'_, i32>) -> &'static str {
         co.yield_(10).await;
         "done"
     }
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn simple_closure() {
-        async fn gen(i: i32, co: Co<'_, i32>) -> &'static str {
+        async fn gen(i: i32, mut co: Co<'_, i32>) -> &'static str {
             co.yield_(i * 2).await;
             "done"
         }
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn resume_args() {
-        async fn gen(resumes: &RefCell<Vec<&str>>, co: Co<'_, i32, &'static str>) {
+        async fn gen(resumes: &RefCell<Vec<&str>>, mut co: Co<'_, i32, &'static str>) {
             let resume_arg = co.yield_(10).await;
             resumes.borrow_mut().push(resume_arg);
             let resume_arg = co.yield_(20).await;
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Co::yield_")]
     fn multiple_yield_helpful_message() {
-        async fn wrong(co: Co<'_, i32>) {
+        async fn wrong(mut co: Co<'_, i32>) {
             let _ = co.yield_(10);
             let _ = co.yield_(20);
         }
@@ -431,7 +431,7 @@ mod tests {
         }
 
         let_gen_using!(gen, shenanigans);
-        let escaped_co = match gen.resume() {
+        let mut escaped_co = match gen.resume() {
             GeneratorState::Yielded(_) => panic!(),
             GeneratorState::Complete(co) => co,
         };
@@ -452,7 +452,7 @@ mod tests {
         let flag = Arc::new(AtomicBool::new(false));
         {
             let capture_the_flag = flag.clone();
-            let_gen_using!(gen, |co| {
+            let_gen_using!(gen, |mut co| {
                 async move {
                     let _set_on_drop = SetFlagOnDrop(capture_the_flag);
                     co.yield_(10).await;

--- a/src/stack/stream.rs
+++ b/src/stack/stream.rs
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn blocking() {
-        async fn produce(co: Co<'_, i32>) {
+        async fn produce(mut co: Co<'_, i32>) {
             co.yield_(10).await;
             co.yield_(20).await;
         }
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn non_blocking() {
-        async fn produce(co: Co<'_, i32>) {
+        async fn produce(mut co: Co<'_, i32>) {
             SlowFuture::new().await;
             co.yield_(10).await;
             SlowFuture::new().await;

--- a/src/sync/boxed.rs
+++ b/src/sync/boxed.rs
@@ -45,7 +45,7 @@ mod tests {
     };
     use std::sync::{Arc, Mutex};
 
-    async fn odd_numbers_less_than_ten(co: Co<i32>) {
+    async fn odd_numbers_less_than_ten(mut co: Co<i32>) {
         for n in (1..).step_by(2).take_while(|&n| n < 10) {
             co.yield_(n).await;
         }

--- a/src/sync/iterator.rs
+++ b/src/sync/iterator.rs
@@ -31,7 +31,7 @@ mod tests {
     use crate::sync::{Co, Gen};
     use std::iter::IntoIterator;
 
-    async fn produce(co: Co<i32>) {
+    async fn produce(mut co: Co<i32>) {
         co.yield_(10).await;
         co.yield_(20).await;
     }

--- a/src/sync/nightly_tests.rs
+++ b/src/sync/nightly_tests.rs
@@ -5,7 +5,7 @@ use crate::{ops::GeneratorState, sync::Gen};
 
 #[test]
 fn async_closure() {
-    let mut gen = Gen::new(async move |co| {
+    let mut gen = Gen::new(async move |mut co| {
         co.yield_(10).await;
         "done"
     });

--- a/src/sync/stream.rs
+++ b/src/sync/stream.rs
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn blocking() {
-        async fn produce(co: Co<i32>) {
+        async fn produce(mut co: Co<i32>) {
             co.yield_(10).await;
             co.yield_(20).await;
         }
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn non_blocking() {
-        async fn produce(co: Co<i32>) {
+        async fn produce(mut co: Co<i32>) {
             SlowFuture::new().await;
             co.yield_(10).await;
             SlowFuture::new().await;

--- a/tests/rc.rs
+++ b/tests/rc.rs
@@ -4,7 +4,7 @@
 
 use genawaiter::rc::{Co, Gen};
 
-async fn odd_numbers_less_than_ten(co: Co<i32>) {
+async fn odd_numbers_less_than_ten(mut co: Co<i32>) {
     for n in (1..).step_by(2).take_while(|&n| n < 10) {
         co.yield_(n).await;
     }

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -4,7 +4,7 @@
 
 use genawaiter::stack::{let_gen_using, Co, Gen, Shelf};
 
-async fn odd_numbers_less_than_ten(co: Co<'_, i32>) {
+async fn odd_numbers_less_than_ten(mut co: Co<'_, i32>) {
     for n in (1..).step_by(2).take_while(|&n| n < 10) {
         co.yield_(n).await;
     }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -4,7 +4,7 @@
 
 use genawaiter::sync::{Co, Gen};
 
-async fn odd_numbers_less_than_ten(co: Co<i32>) {
+async fn odd_numbers_less_than_ten(mut co: Co<i32>) {
     for n in (1..).step_by(2).take_while(|&n| n < 10) {
         co.yield_(n).await;
     }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,7 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/rc_fail_not_awaiting_yield.rs");
+    t.compile_fail("tests/ui/stack_fail_not_awaiting_yield.rs");
+    t.compile_fail("tests/ui/sync_fail_not_awaiting_yield.rs");
+}

--- a/tests/ui/rc_fail_not_awaiting_yield.rs
+++ b/tests/ui/rc_fail_not_awaiting_yield.rs
@@ -1,0 +1,11 @@
+use genawaiter::{rc::Co};
+
+#[allow(unused_variables)]
+async fn wrong(mut co: Co<i32>) {
+    let foo = co.yield_(10);
+    let bar = co.yield_(20);
+}
+
+fn main() {
+
+}

--- a/tests/ui/rc_fail_not_awaiting_yield.stderr
+++ b/tests/ui/rc_fail_not_awaiting_yield.stderr
@@ -1,0 +1,9 @@
+error[E0499]: cannot borrow `co` as mutable more than once at a time
+ --> $DIR/rc_fail_not_awaiting_yield.rs:6:15
+  |
+5 |     let foo = co.yield_(10);
+  |               -- first mutable borrow occurs here
+6 |     let bar = co.yield_(20);
+  |               ^^ second mutable borrow occurs here
+7 | }
+  | - first borrow might be used here, when `foo` is dropped and runs the destructor for type `impl std::future::Future`

--- a/tests/ui/stack_fail_not_awaiting_yield.rs
+++ b/tests/ui/stack_fail_not_awaiting_yield.rs
@@ -1,0 +1,11 @@
+use genawaiter::{stack::Co};
+
+#[allow(unused_variables)]
+async fn wrong(mut co: Co<i32>) {
+    let foo = co.yield_(10);
+    let bar = co.yield_(20);
+}
+
+fn main() {
+
+}

--- a/tests/ui/stack_fail_not_awaiting_yield.stderr
+++ b/tests/ui/stack_fail_not_awaiting_yield.stderr
@@ -1,0 +1,5 @@
+error[E0726]: implicit elided lifetime not allowed here
+ --> $DIR/stack_fail_not_awaiting_yield.rs:4:24
+  |
+4 | async fn wrong(mut co: Co<i32>) {
+  |                        ^^^^^^^ help: indicate the anonymous lifetime: `Co<'_, i32>`

--- a/tests/ui/sync_fail_not_awaiting_yield.rs
+++ b/tests/ui/sync_fail_not_awaiting_yield.rs
@@ -1,0 +1,11 @@
+use genawaiter::{sync::Co};
+
+#[allow(unused_variables)]
+async fn wrong(mut co: Co<i32>) {
+    let foo = co.yield_(10);
+    let bar = co.yield_(20);
+}
+
+fn main() {
+
+}

--- a/tests/ui/sync_fail_not_awaiting_yield.stderr
+++ b/tests/ui/sync_fail_not_awaiting_yield.stderr
@@ -1,0 +1,9 @@
+error[E0499]: cannot borrow `co` as mutable more than once at a time
+ --> $DIR/sync_fail_not_awaiting_yield.rs:6:15
+  |
+5 |     let foo = co.yield_(10);
+  |               -- first mutable borrow occurs here
+6 |     let bar = co.yield_(20);
+  |               ^^ second mutable borrow occurs here
+7 | }
+  | - first borrow might be used here, when `foo` is dropped and runs the destructor for type `impl std::future::Future`


### PR DESCRIPTION
This is an initial patch that implements the idea described in #15.
We could actually go further than this. With the mutable reference to `self` available inside `Co`, we could also make `Airlock` take a mutable reference and just use a regular `mem::replace` in all cases.

With this, we could get rid of some unsafe code, a Mutex, and a usage of cell!

The tests are all passing but I am not sure if that means it would be good to merge:

1. Making it a `&mut self` automatically makes the type non-sync. There seem to be no tests to ensure that the type is sync so I don't know if that is a requirement?
2. The old tests for ensuring that `yield_` panics actually still pass because the assign the future to `_` and hence it gets dropped immediately, freeing the mutable reference to be taken again.