### PR TITLE
Fixes UB in `stack::generator`: Aliasing violations and references to uninit memory.

### DIFF
--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -117,6 +117,23 @@ fn stack_yield_match() {
     assert_eq!(vec![1, 3, 5, 7, 9], res)
 }
 
+#[test]
+fn stack_yield_closure_no_macro() {
+    let mut shelf = genawaiter::stack::Shelf::new();
+    let gen = unsafe {
+        Gen::new(&mut shelf, |co| async move {
+            let mut n = 1;
+            while n < 10 {
+                co.yield_(n).await;
+                n += 2;
+            }
+        })
+    };
+
+    let res = gen.into_iter().collect::<Vec<_>>();
+    assert_eq!(vec![1, 3, 5, 7, 9], res)
+}
+
 #[cfg(feature = "proc_macro")]
 #[test]
 fn stack_yield_closure() {


### PR DESCRIPTION
While looking through the code I noticed some issues with unsound usage of `MaybeUninit` as well as one aliasing violation. Instead of opening an issue I decided to try and fix it myself. I have not looked at the the other modules, so there may be similar issues there.

### Issues

https://github.com/whatisaphone/genawaiter/blob/3e9652adcf212da1abeb4d3eded7f487a7ab5478/src/stack/generator.rs#L92-L93

Here `as_mut_ptr` returns a `*mut T` to uninitialized memory. De-referencing it is UB, which is also unnecessary, since it is turned back into a raw pointer anyways in the same line.
Lines 96 and 99 cause UB in a similar manner, i.e., by de-referencing a pointer to uninitialized memory.

https://github.com/whatisaphone/genawaiter/blob/3e9652adcf212da1abeb4d3eded7f487a7ab5478/src/stack/generator.rs#L88-L99

The aliasing issue is more subtle: `Gen::new` receives a mutable reference to a `Shelf` and stores it within itself as a `Pin<&mut _>`, however, the future that is created by `producer` receives a shared reference to the `Airlock`, which it may store within itself. This is a bit weird, since it is a reference into the same struct, but I believe it constitutes a violation of the aliasing rules, because there exists at the same time a (pinned) mutable reference to the `Shelf` and a shared reference to the `Airlock` within the same `Shelf`.

### Changes

- the `Airlock` is initialized regularly, without the use of `MaybeUninit`
- the `future` is initialized correctly through a raw pointer write
- the `shelf` borrow is split into a mutable and pinned borrow of `future` and a shared borrow of `airlock`, which means the aliasing rules are maintained (I think)

### Discussion

I am sure, if `Gen::new` has to be an unsafe function. I assume that it would be possible to violate memory safety if it were possible to find a way to get the `producer` closure to move the `Co` instance out and in between the `Shelf` and the `Gen` like so:

```rust
let mut shelf = Shelf::new();
let mut outer_co = None;
let gen = Gen::new(&mut shelf, |co| {
    outer_co = Some(co);
    // ...
});
// ... complete generator, then use outer_co somehow
```

I have not found a way to get something like this to compile however, so maybe `Gen::new` could be declared as safe?

EDIT:
Having read through the other PR about making `Co::yield_` take `&mut self` I've seen it is indeed possible to let the `co` instance escape, but since `airlock` is now initialized regularly and only dropped alongside the `shelf`, I think it is safe to let it escape the closure and try to yield stuff from it after the the generator is complete, the code will simply panic without any violations of memory safety.