### PR TITLE
Update to more recent Rust

### DIFF
--- a/examples/error_propagation.rs
+++ b/examples/error_propagation.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let counter = gen!({
             for num in 0..10 {
                 // Perform some fallible operation, and yield the result (or the error)
-                let string = yield_!(process(num));
+                let _string = yield_!(process(num));
             }
         });
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,9 +266,6 @@ extern crate self as genawaiter;
 
 pub use crate::ops::{Coroutine, Generator, GeneratorState};
 
-#[cfg(feature = "proc_macro")]
-use proc_macro_hack::proc_macro_hack;
-
 /// Creates a producer for use with [`sync::Gen`].
 ///
 /// A producer can later be turned into a generator using
@@ -290,7 +287,6 @@ use proc_macro_hack::proc_macro_hack;
 /// # my_generator.resume();
 /// ```
 #[cfg(feature = "proc_macro")]
-#[proc_macro_hack]
 pub use genawaiter_proc_macro::sync_producer;
 
 /// Creates a producer for use with [`rc::Gen`].
@@ -314,12 +310,10 @@ pub use genawaiter_proc_macro::sync_producer;
 /// # my_generator.resume();
 /// ```
 #[cfg(feature = "proc_macro")]
-#[proc_macro_hack]
 pub use genawaiter_proc_macro::rc_producer;
 
 #[doc(hidden)] // This is not quite usable currently, so hide it for now.
 #[cfg(feature = "proc_macro")]
-#[proc_macro_hack]
 pub use genawaiter_proc_macro::stack_producer;
 
 mod core;

--- a/src/stack/nightly_tests.rs
+++ b/src/stack/nightly_tests.rs
@@ -5,7 +5,7 @@ use crate::{ops::GeneratorState, stack::let_gen_using};
 
 #[test]
 fn async_closure() {
-    let_gen_using!(gen, async move |co| {
+    let_gen_using!(gen, async move |mut co| {
         co.yield_(10).await;
         "done"
     });


### PR DESCRIPTION
## replace proc_macro_hack with proc_macro

This allows nested macro executions (and therefore allows macros in other crates to abstract the gen macros).

## add rust-toolchain with nightly toolchain

Otherwise, `cargo check --all-features` fails, because it attempts to enable the nightly feature and fails on stable.

## fix a few lints

Similarly, `cargo check --all-features` enables `feature = "strict"`, which turns the warnings into hard errors. I'm not sure if they were present a year ago (and ignored), but they fail the build today with `--all-features`.