### PR TITLE
add `no_std` compatibility and remove `Coroutine` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,12 @@ rustversion = "1.0.2"
 trybuild = "1"
 
 [features]
-default = ["proc_macro"]
+alloc = []
+default = ["proc_macro", "rc", "sync"]
 futures03 = ["futures-core"]
 nightly = []
-strict = []
 proc_macro = ["genawaiter-proc-macro", "proc-macro-hack", "genawaiter-macro/proc_macro"]
+rc = []
+std = []
+strict = []
+sync = []

--- a/genawaiter-proc-macro/src/lib.rs
+++ b/genawaiter-proc-macro/src/lib.rs
@@ -9,7 +9,6 @@ use proc_macro::TokenStream;
 use proc_macro_error::{abort, abort_call_site, proc_macro_error};
 use proc_macro_hack::proc_macro_hack;
 use quote::quote;
-use std::string::ToString;
 use syn::{
     self,
     parse_macro_input,

--- a/genawaiter-proc-macro/src/lib.rs
+++ b/genawaiter-proc-macro/src/lib.rs
@@ -2,8 +2,6 @@
 #![warn(clippy::cargo, clippy::pedantic)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 
-extern crate proc_macro;
-
 use crate::visit::YieldReplace;
 use proc_macro::TokenStream;
 use proc_macro_error::{abort, abort_call_site, proc_macro_error};

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,5 @@
 use crate::{ops::GeneratorState, waker};
-use std::{
+use core::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
-use std::mem;
+use core::mem;
 
 pub trait MaybeUninitExt<T> {
     unsafe fn assume_init_get_mut(&mut self) -> &mut T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,7 @@ Values can be yielded from the generator by calling `yield_`, and immediately aw
 the future it returns. You can get these values out of the generator in either of two
 ways:
 
-- Call `resume()` or `resume_with()`. The values will be returned in a
-  `GeneratorState::Yielded`.
+- Call `resume()`. The values will be returned in a `GeneratorState::Yielded`.
 
   ```rust
   # #[cfg(feature = "proc_macro")]
@@ -129,7 +128,7 @@ ways:
   let mut generator = gen!({
       yield_!(10);
   });
-  let ten = generator.resume();
+  let ten = generator.resume(());
   assert_eq!(ten, GeneratorState::Yielded(10));
   # }
   ```
@@ -152,7 +151,7 @@ ways:
 
 ## Resume
 
-You can also send values back into the generator, by using `resume_with`. The generator
+You can also send values back into the generator, by using `resume`. The generator
 receives them from the future returned by `yield_`.
 
 ```rust
@@ -166,8 +165,8 @@ let mut printer = gen!({
         println!("{}", string);
     }
 });
-printer.resume_with("hello");
-printer.resume_with("world");
+printer.resume("hello");
+printer.resume("world");
 # }
 ```
 
@@ -185,8 +184,8 @@ let mut generator = gen!({
     yield_!(10);
     "done"
 });
-assert_eq!(generator.resume(), GeneratorState::Yielded(10));
-assert_eq!(generator.resume(), GeneratorState::Complete("done"));
+assert_eq!(generator.resume(()), GeneratorState::Yielded(10));
+assert_eq!(generator.resume(()), GeneratorState::Complete("done"));
 # }
 ```
 
@@ -236,7 +235,7 @@ works even without the `futures03` feature.)
 #     yield_!(10);
 # });
 #
-match gen.async_resume().await {
+match gen.async_resume(()).await {
     GeneratorState::Yielded(_) => {}
     GeneratorState::Complete(_) => {}
 }
@@ -250,10 +249,6 @@ This crate supplies [`Generator`](trait.Generator.html) and
 stability attributes removed) so they can be used on stable Rust. If/when real
 generators are stabilized, hopefully they would be drop-in replacements. Javascript
 developers might recognize this as a polyfill.
-
-There is also a [`Coroutine`](trait.Coroutine.html) trait, which does not come from the
-stdlib. A `Coroutine` is a generalization of a `Generator`. A `Generator` constrains the
-resume argument type to `()`, but in a `Coroutine` it can be anything.
 */
 
 #![cfg_attr(feature = "nightly", feature(async_closure))]
@@ -264,7 +259,7 @@ resume argument type to `()`, but in a `Coroutine` it can be anything.
 #[cfg(test)]
 extern crate self as genawaiter;
 
-pub use crate::ops::{Coroutine, Generator, GeneratorState};
+pub use crate::ops::{Generator, GeneratorState};
 
 #[cfg(feature = "proc_macro")]
 use proc_macro_hack::proc_macro_hack;
@@ -287,7 +282,7 @@ use proc_macro_hack::proc_macro_hack;
 /// });
 ///
 /// let mut my_generator = Gen::new(my_producer);
-/// # my_generator.resume();
+/// # my_generator.resume(());
 /// ```
 #[cfg(feature = "proc_macro")]
 #[proc_macro_hack]
@@ -311,7 +306,7 @@ pub use genawaiter_proc_macro::sync_producer;
 /// });
 ///
 /// let mut my_generator = Gen::new(my_producer);
-/// # my_generator.resume();
+/// # my_generator.resume(());
 /// ```
 #[cfg(feature = "proc_macro")]
 #[proc_macro_hack]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ works even without the `futures03` feature.)
 # #[cfg(feature = "proc_macro")]
 # async fn feature_gate() {
 # use genawaiter::{sync::gen, yield_, GeneratorState};
-# use std::task::Poll;
+# use core::task::Poll;
 #
 # let mut gen = gen!({
 #     yield_!(10);
@@ -322,8 +322,10 @@ mod ext;
 #[macro_use]
 mod macros;
 mod ops;
+#[cfg(feature = "rc")]
 pub mod rc;
 pub mod stack;
+#[cfg(feature = "sync")]
 pub mod sync;
 #[cfg(test)]
 mod testing;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,6 +30,6 @@ macro_rules! pin_mut {
     ($x:ident) => {
         let mut $x = $x;
         #[allow(unused_mut)]
-        let mut $x = unsafe { ::std::pin::Pin::new_unchecked(&mut $x) };
+        let mut $x = unsafe { ::core::pin::Pin::new_unchecked(&mut $x) };
     };
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,4 +1,4 @@
-use std::pin::Pin;
+use core::pin::Pin;
 
 /// A trait implemented for generator types.
 ///

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,32 +1,9 @@
 use std::pin::Pin;
 
-/// A trait implemented for coroutines.
-///
-/// A `Coroutine` is a generalization of a `Generator`. A `Generator` constrains
-/// the resume argument type to `()`, but in a `Coroutine` it can be anything.
-pub trait Coroutine {
-    /// The type of value this generator yields.
-    type Yield;
-
-    /// The type of value this generator accepts as a resume argument.
-    type Resume;
-
-    /// The type of value this generator returns upon completion.
-    type Return;
-
-    /// Resumes the execution of this generator.
-    ///
-    /// The argument will be passed into the coroutine as a resume argument.
-    fn resume_with(
-        self: Pin<&mut Self>,
-        arg: Self::Resume,
-    ) -> GeneratorState<Self::Yield, Self::Return>;
-}
-
 /// A trait implemented for generator types.
 ///
-/// This is modeled after the stdlib's nightly-only [`std::ops::Generator`].
-pub trait Generator {
+/// This is modeled after the stdlib's nightly-only [`core::ops::Generator`].
+pub trait Generator<R = ()> {
     /// The type of value this generator yields.
     type Yield;
 
@@ -34,29 +11,32 @@ pub trait Generator {
     type Return;
 
     /// Resumes the execution of this generator.
-    fn resume(self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return>;
-}
-
-impl<C: Coroutine<Resume = ()>> Generator for C {
-    type Yield = <Self as Coroutine>::Yield;
-    type Return = <Self as Coroutine>::Return;
-
-    #[must_use]
-    fn resume(self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return> {
-        self.resume_with(())
-    }
+    fn resume(self: Pin<&mut Self>, arg: R) -> GeneratorState<Self::Yield, Self::Return>;
 }
 
 /// The result of a generator resumption.
 ///
 /// This is modeled after the stdlib's nightly-only
-/// [`std::ops::GeneratorState`].
+/// [`core::ops::GeneratorState`].
+///
+/// This enum is returned from the [`Generator::resume`] method and indicates
+/// the possible return values of a generator. Currently this corresponds to
+/// either a suspension point (Yielded) or a termination point (Complete).
 #[derive(PartialEq, Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub enum GeneratorState<Y, R> {
     /// The generator suspended with a value.
+    ///
+    /// This state indicates that a generator has been suspended, and typically
+    /// corresponds to a yield statement. The value provided in this variant
+    /// corresponds to the expression passed to yield and allows generators to
+    /// provide a value each time they yield.
     Yielded(Y),
 
     /// The generator completed with a return value.
+    ///
+    /// This state indicates that a generator has finished execution with the
+    /// provided value. Once a generator has returned Complete it is considered
+    /// a programmer error to call resume again.
     Complete(R),
 }

--- a/src/rc/engine.rs
+++ b/src/rc/engine.rs
@@ -1,5 +1,8 @@
+extern crate alloc;
+
 use crate::{core, core::Next};
-use std::{cell::Cell, rc::Rc};
+use ::core::cell::Cell;
+use alloc::rc::Rc;
 
 pub struct Airlock<Y, R>(Rc<Cell<Next<Y, R>>>);
 

--- a/src/rc/generator.rs
+++ b/src/rc/generator.rs
@@ -3,7 +3,7 @@ use crate::{
     ops::{Generator, GeneratorState},
     rc::{engine::Airlock, Co},
 };
-use std::{future::Future, pin::Pin};
+use core::{future::Future, pin::Pin};
 
 /// This is a generator which stores its state on the heap.
 ///

--- a/src/rc/generator.rs
+++ b/src/rc/generator.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{advance, async_advance, Airlock as _, Next},
-    ops::{Coroutine, GeneratorState},
+    ops::{Generator, GeneratorState},
     rc::{engine::Airlock, Co},
 };
 use std::{future::Future, pin::Pin};
@@ -42,23 +42,13 @@ impl<Y, R, F: Future> Gen<Y, R, F> {
     /// `Completed` is returned.
     ///
     /// [_See the module-level docs for examples._](.)
-    pub fn resume_with(&mut self, arg: R) -> GeneratorState<Y, F::Output> {
+    pub fn resume(&mut self, arg: R) -> GeneratorState<Y, F::Output> {
         self.airlock.replace(Next::Resume(arg));
         advance(self.future.as_mut(), &self.airlock)
     }
 }
 
-impl<Y, F: Future> Gen<Y, (), F> {
-    /// Resumes execution of the generator.
-    ///
-    /// If the generator yields a value, `Yielded` is returned. Otherwise,
-    /// `Completed` is returned.
-    ///
-    /// [_See the module-level docs for examples._](.)
-    pub fn resume(&mut self) -> GeneratorState<Y, F::Output> {
-        self.resume_with(())
-    }
-
+impl<Y, R, F: Future> Gen<Y, R, F> {
     /// Resumes execution of the generator.
     ///
     /// If the generator pauses without yielding, `Poll::Pending` is returned.
@@ -68,21 +58,21 @@ impl<Y, F: Future> Gen<Y, (), F> {
     /// [_See the module-level docs for examples._](.)
     pub fn async_resume(
         &mut self,
+        arg: R,
     ) -> impl Future<Output = GeneratorState<Y, F::Output>> + '_ {
-        self.airlock.replace(Next::Resume(()));
+        self.airlock.replace(Next::Resume(arg));
         async_advance(self.future.as_mut(), self.airlock.clone())
     }
 }
 
-impl<Y, R, F: Future> Coroutine for Gen<Y, R, F> {
+impl<Y, R, F: Future> Generator<R> for Gen<Y, R, F> {
     type Yield = Y;
-    type Resume = R;
     type Return = F::Output;
 
-    fn resume_with(
+    fn resume(
         mut self: Pin<&mut Self>,
         arg: R,
     ) -> GeneratorState<Self::Yield, Self::Return> {
-        Self::resume_with(&mut *self, arg)
+        Self::resume(&mut *self, arg)
     }
 }

--- a/src/rc/iterator.rs
+++ b/src/rc/iterator.rs
@@ -1,5 +1,5 @@
 use crate::{ops::GeneratorState, rc::Gen};
-use std::future::Future;
+use core::future::Future;
 
 impl<Y, F: Future<Output = ()>> IntoIterator for Gen<Y, (), F> {
     type Item = Y;
@@ -29,7 +29,7 @@ impl<Y, F: Future<Output = ()>> Iterator for IntoIter<Y, F> {
 #[cfg(test)]
 mod tests {
     use crate::rc::{Co, Gen};
-    use std::iter::IntoIterator;
+    use core::iter::IntoIterator;
 
     async fn produce(mut co: Co<i32>) {
         co.yield_(10).await;

--- a/src/rc/iterator.rs
+++ b/src/rc/iterator.rs
@@ -19,7 +19,7 @@ impl<Y, F: Future<Output = ()>> Iterator for IntoIter<Y, F> {
     type Item = Y;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.generator.resume() {
+        match self.generator.resume(()) {
             GeneratorState::Yielded(x) => Some(x),
             GeneratorState::Complete(()) => None,
         }

--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -13,7 +13,7 @@ You can create a basic generator with [`gen!`] and [`yield_!`].
 let mut my_generator = gen!({
     yield_!(10);
 });
-# my_generator.resume();
+# my_generator.resume(());
 # }
 ```
 
@@ -29,7 +29,7 @@ let my_producer = producer!({
     yield_!(10);
 });
 let mut my_generator = Gen::new(my_producer);
-# my_generator.resume();
+# my_generator.resume(());
 # }
 ```
 
@@ -42,7 +42,7 @@ async fn my_producer(mut co: Co<u8>) {
     co.yield_(10).await;
 }
 let mut my_generator = Gen::new(my_producer);
-# my_generator.resume();
+# my_generator.resume(());
 ```
 
 # Examples
@@ -102,7 +102,7 @@ let two = 2;
 let mut multiply = gen!({
     yield_!(10 * two);
 });
-assert_eq!(multiply.resume(), GeneratorState::Yielded(20));
+assert_eq!(multiply.resume(()), GeneratorState::Yielded(20));
 # }
 ```
 
@@ -117,12 +117,12 @@ assert_eq!(multiply.resume(), GeneratorState::Yielded(20));
 #     for n in (1..).step_by(2).take_while(|&n| n < 10) { yield_!(n); }
 # });
 #
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(1));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(3));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(5));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(7));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(9));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Complete(()));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(1));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(3));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(5));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(7));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(9));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Complete(()));
 # }
 ```
 
@@ -147,9 +147,9 @@ let mut check_numbers = gen!({
     assert_eq!(num, 2);
 });
 
-check_numbers.resume_with(0);
-check_numbers.resume_with(1);
-check_numbers.resume_with(2);
+check_numbers.resume(0);
+check_numbers.resume(1);
+check_numbers.resume(2);
 # }
 ```
 
@@ -169,9 +169,9 @@ let mut numbers_then_string = gen!({
     "done!"
 });
 
-assert_eq!(numbers_then_string.resume(), GeneratorState::Yielded(10));
-assert_eq!(numbers_then_string.resume(), GeneratorState::Yielded(20));
-assert_eq!(numbers_then_string.resume(), GeneratorState::Complete("done!"));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Yielded(10));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Yielded(20));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Complete("done!"));
 # }
 ```
 
@@ -188,7 +188,7 @@ async fn produce() {
 }
 
 let mut gen = Gen::new(produce);
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
 # }
 ```
 
@@ -205,7 +205,7 @@ let produce = producer!({
 });
 
 let mut gen = Gen::new(produce);
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
 # }
 ```
 
@@ -239,9 +239,9 @@ let gen = Gen::new(async move |co| {
     co.yield_(10).await;
     co.yield_(20).await;
 });
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Complete(()));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Complete(()));
 ```
 
 ## Using the low-level API with an async <del>closure</del> faux·sure (for stable Rust)
@@ -253,9 +253,9 @@ let mut gen = Gen::new(|mut co| async move {
     co.yield_(10).await;
     co.yield_(20).await;
 });
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Complete(()));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Complete(()));
 ```
 
 ## Using the low-level API with function arguments
@@ -274,9 +274,9 @@ async fn multiples_of(num: i32, mut co: Co<i32>) {
 }
 
 let mut gen = Gen::new(|co| multiples_of(10, co));
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Yielded(30));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(30));
 ```
 */
 
@@ -334,8 +334,8 @@ mod tests {
     #[test]
     fn function() {
         let mut gen = Gen::new(simple_producer);
-        assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
     }
 
     #[test]
@@ -346,8 +346,8 @@ mod tests {
         }
 
         let mut gen = Gen::new(|co| gen(5, co));
-        assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
     }
 
     #[test]
@@ -363,13 +363,13 @@ mod tests {
         let mut gen = Gen::new(|co| gen(&resumes, co));
         assert_eq!(*resumes.borrow(), &[] as &[&str]);
 
-        assert_eq!(gen.resume_with("ignored"), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume("ignored"), GeneratorState::Yielded(10));
         assert_eq!(*resumes.borrow(), &[] as &[&str]);
 
-        assert_eq!(gen.resume_with("abc"), GeneratorState::Yielded(20));
+        assert_eq!(gen.resume("abc"), GeneratorState::Yielded(20));
         assert_eq!(*resumes.borrow(), &["abc"]);
 
-        assert_eq!(gen.resume_with("def"), GeneratorState::Complete(()));
+        assert_eq!(gen.resume("def"), GeneratorState::Complete(()));
         assert_eq!(*resumes.borrow(), &["abc", "def"]);
     }
 
@@ -381,7 +381,7 @@ mod tests {
         }
 
         let mut gen = Gen::new(wrong);
-        gen.resume();
+        gen.resume(());
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
         }
 
         let mut gen = Gen::new(wrong);
-        gen.resume();
+        gen.resume(());
     }
 
     #[test]
@@ -404,7 +404,7 @@ mod tests {
         }
 
         let mut gen = Gen::new(shenanigans);
-        let mut escaped_co = match gen.resume() {
+        let mut escaped_co = match gen.resume(()) {
             GeneratorState::Yielded(_) => panic!(),
             GeneratorState::Complete(co) => co,
         };
@@ -454,15 +454,15 @@ mod tests {
             addrs: &mut Vec<*const i32>,
         ) -> Gen<i32, (), impl Future<Output = &'static str> + '_> {
             let mut gen = Gen::new(move |co| produce(addrs, co));
-            assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+            assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
             gen
         }
 
         let mut addrs = Vec::new();
         let mut gen = create_generator(&mut addrs);
 
-        assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
         drop(gen);
 
         assert!(addrs.iter().all(|&p| p == addrs[0]));

--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -321,7 +321,7 @@ mod tests {
         testing::DummyFuture,
         GeneratorState,
     };
-    use std::{
+    use core::{
         cell::{Cell, RefCell},
         future::Future,
     };

--- a/src/rc/nightly_tests.rs
+++ b/src/rc/nightly_tests.rs
@@ -9,6 +9,6 @@ fn async_closure() {
         co.yield_(10).await;
         "done"
     });
-    assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-    assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+    assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+    assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
 }

--- a/src/rc/stream.rs
+++ b/src/rc/stream.rs
@@ -12,7 +12,7 @@ impl<Y, F: Future<Output = ()>> Stream for Gen<Y, (), F> {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        let fut = self.async_resume();
+        let fut = self.async_resume(());
         pin_mut!(fut);
         match fut.poll(cx) {
             Poll::Ready(GeneratorState::Yielded(x)) => Poll::Ready(Some(x)),

--- a/src/rc/stream.rs
+++ b/src/rc/stream.rs
@@ -3,7 +3,7 @@ use futures_core::{
     task::{Context, Poll},
     Stream,
 };
-use std::{future::Future, pin::Pin};
+use core::{future::Future, pin::Pin};
 
 impl<Y, F: Future<Output = ()>> Stream for Gen<Y, (), F> {
     type Item = Y;

--- a/src/stack/engine.rs
+++ b/src/stack/engine.rs
@@ -1,5 +1,5 @@
 use crate::{core, core::Next};
-use std::{cell::UnsafeCell, ptr};
+use ::core::{cell::UnsafeCell, ptr};
 
 /// This type holds the value that is pending being returned from the generator.
 ///

--- a/src/stack/generator.rs
+++ b/src/stack/generator.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, mem::MaybeUninit, pin::Pin, ptr};
+use core::{future::Future, mem::MaybeUninit, pin::Pin, ptr};
 
 use crate::{
     core::{advance, async_advance, Airlock as _, Next},

--- a/src/stack/iterator.rs
+++ b/src/stack/iterator.rs
@@ -19,7 +19,7 @@ impl<'s, Y, F: Future<Output = ()>> Iterator for IntoIter<'s, Y, F> {
     type Item = Y;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.generator.resume() {
+        match self.generator.resume(()) {
             GeneratorState::Yielded(x) => Some(x),
             GeneratorState::Complete(()) => None,
         }
@@ -43,7 +43,7 @@ impl<'r, 's, Y, F: Future<Output = ()>> Iterator for MutIntoIter<'r, 's, Y, F> {
     type Item = Y;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.generator.resume() {
+        match self.generator.resume(()) {
             GeneratorState::Yielded(x) => Some(x),
             GeneratorState::Complete(()) => None,
         }

--- a/src/stack/iterator.rs
+++ b/src/stack/iterator.rs
@@ -1,5 +1,5 @@
 use crate::{ops::GeneratorState, stack::generator::Gen};
-use std::future::Future;
+use core::future::Future;
 
 impl<'s, Y, F: Future<Output = ()>> IntoIterator for Gen<'s, Y, (), F> {
     type Item = Y;
@@ -53,7 +53,7 @@ impl<'r, 's, Y, F: Future<Output = ()>> Iterator for MutIntoIter<'r, 's, Y, F> {
 #[cfg(test)]
 mod tests {
     use crate::stack::{let_gen_using, Co, Gen, Shelf};
-    use std::iter::IntoIterator;
+    use core::iter::IntoIterator;
 
     async fn produce(mut co: Co<'_, i32>) {
         co.yield_(10).await;

--- a/src/stack/macros.rs
+++ b/src/stack/macros.rs
@@ -52,7 +52,7 @@ mod tests {
         let mut gen = unsafe { Gen::new(&mut shelf, shenanigans) };
 
         // Get the `co` out of the generator (don't try this at home).
-        let mut escaped_co = match gen.resume() {
+        let mut escaped_co = match gen.resume(()) {
             GeneratorState::Yielded(_) => panic!(),
             GeneratorState::Complete(co) => co,
         };

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -340,18 +340,18 @@ mod nightly_tests;
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use crate::{
         stack::{let_gen_using, Co},
         testing::DummyFuture,
         GeneratorState,
     };
-    use std::{
+    use core::{
         cell::RefCell,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc,
-        },
+        sync::atomic::{AtomicBool, Ordering},
     };
+    use alloc::sync::Arc;
 
     async fn simple_producer(mut co: Co<'_, i32>) -> &'static str {
         co.yield_(10).await;

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -13,7 +13,7 @@ You can create a basic generator with [`let_gen!`] and [`yield_!`].
 let_gen!(my_generator, {
     yield_!(10);
 });
-# my_generator.resume();
+# my_generator.resume(());
 # }
 ```
 
@@ -28,7 +28,7 @@ async fn my_producer(mut co: Co<'_, u8>) {
 }
 let mut shelf = Shelf::new();
 let mut my_generator = unsafe { Gen::new(&mut shelf, my_producer) };
-# my_generator.resume();
+# my_generator.resume(());
 ```
 
 # Examples
@@ -88,7 +88,7 @@ let two = 2;
 let_gen!(multiply, {
     yield_!(10 * two);
 });
-assert_eq!(multiply.resume(), GeneratorState::Yielded(20));
+assert_eq!(multiply.resume(()), GeneratorState::Yielded(20));
 # }
 ```
 
@@ -103,12 +103,12 @@ assert_eq!(multiply.resume(), GeneratorState::Yielded(20));
 #     for n in (1..).step_by(2).take_while(|&n| n < 10) { yield_!(n); }
 # });
 #
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(1));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(3));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(5));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(7));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(9));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Complete(()));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(1));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(3));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(5));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(7));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(9));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Complete(()));
 # }
 ```
 
@@ -133,9 +133,9 @@ let_gen!(check_numbers, {
     assert_eq!(num, 2);
 });
 
-check_numbers.resume_with(0);
-check_numbers.resume_with(1);
-check_numbers.resume_with(2);
+check_numbers.resume(0);
+check_numbers.resume(1);
+check_numbers.resume(2);
 # }
 ```
 
@@ -155,9 +155,9 @@ let_gen!(numbers_then_string, {
     "done!"
 });
 
-assert_eq!(numbers_then_string.resume(), GeneratorState::Yielded(10));
-assert_eq!(numbers_then_string.resume(), GeneratorState::Yielded(20));
-assert_eq!(numbers_then_string.resume(), GeneratorState::Complete("done!"));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Yielded(10));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Yielded(20));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Complete("done!"));
 # }
 ```
 
@@ -174,7 +174,7 @@ async fn produce() {
 }
 
 let_gen_using!(gen, produce);
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
 # }
 ```
 
@@ -208,9 +208,9 @@ let_gen_using!(gen, async move |co| {
     co.yield_(10).await;
     co.yield_(20).await;
 });
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Complete(()));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Complete(()));
 ```
 
 ## Using the low-level API with an async <del>closure</del> faux·sure (for stable Rust)
@@ -222,9 +222,9 @@ let_gen_using!(gen, |mut co| async move {
     co.yield_(10).await;
     co.yield_(20).await;
 });
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Complete(()));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Complete(()));
 ```
 
 ## Using the low-level API with function arguments
@@ -243,9 +243,9 @@ async fn multiples_of(num: i32, mut co: Co<'_, i32>) {
 }
 
 let_gen_using!(gen, |co| multiples_of(10, co));
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Yielded(30));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(30));
 ```
 */
 
@@ -361,8 +361,8 @@ mod tests {
     #[test]
     fn function() {
         let_gen_using!(gen, simple_producer);
-        assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
     }
 
     #[test]
@@ -373,8 +373,8 @@ mod tests {
         }
 
         let_gen_using!(gen, |co| gen(5, co));
-        assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
     }
 
     #[test]
@@ -390,13 +390,13 @@ mod tests {
         let_gen_using!(gen, |co| gen(&resumes, co));
         assert_eq!(*resumes.borrow(), &[] as &[&str]);
 
-        assert_eq!(gen.resume_with("ignored"), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume("ignored"), GeneratorState::Yielded(10));
         assert_eq!(*resumes.borrow(), &[] as &[&str]);
 
-        assert_eq!(gen.resume_with("abc"), GeneratorState::Yielded(20));
+        assert_eq!(gen.resume("abc"), GeneratorState::Yielded(20));
         assert_eq!(*resumes.borrow(), &["abc"]);
 
-        assert_eq!(gen.resume_with("def"), GeneratorState::Complete(()));
+        assert_eq!(gen.resume("def"), GeneratorState::Complete(()));
         assert_eq!(*resumes.borrow(), &["abc", "def"]);
     }
 
@@ -408,7 +408,7 @@ mod tests {
         }
 
         let_gen_using!(gen, wrong);
-        gen.resume();
+        gen.resume(());
     }
 
     #[test]
@@ -420,7 +420,7 @@ mod tests {
         }
 
         let_gen_using!(gen, wrong);
-        gen.resume();
+        gen.resume(());
     }
 
     #[test]
@@ -431,7 +431,7 @@ mod tests {
         }
 
         let_gen_using!(gen, shenanigans);
-        let mut escaped_co = match gen.resume() {
+        let mut escaped_co = match gen.resume(()) {
             GeneratorState::Yielded(_) => panic!(),
             GeneratorState::Complete(co) => co,
         };
@@ -460,7 +460,7 @@ mod tests {
                     unreachable!();
                 }
             });
-            assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+            assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
             // `gen` is only a reference to the generator, and dropping a reference has
             // no effect. The underlying generator is hidden behind macro hygiene and so
             // cannot be dropped early.

--- a/src/stack/nightly_tests.rs
+++ b/src/stack/nightly_tests.rs
@@ -9,6 +9,6 @@ fn async_closure() {
         co.yield_(10).await;
         "done"
     });
-    assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-    assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+    assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+    assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
 }

--- a/src/stack/stream.rs
+++ b/src/stack/stream.rs
@@ -12,7 +12,7 @@ impl<'s, Y, F: Future<Output = ()>> Stream for Gen<'s, Y, (), F> {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        let fut = self.async_resume();
+        let fut = self.async_resume(());
         pin_mut!(fut);
         match fut.poll(cx) {
             Poll::Ready(GeneratorState::Yielded(x)) => Poll::Ready(Some(x)),

--- a/src/stack/stream.rs
+++ b/src/stack/stream.rs
@@ -3,7 +3,7 @@ use futures_core::{
     task::{Context, Poll},
     Stream,
 };
-use std::{future::Future, pin::Pin};
+use core::{future::Future, pin::Pin};
 
 impl<'s, Y, F: Future<Output = ()>> Stream for Gen<'s, Y, (), F> {
     type Item = Y;

--- a/src/sync/boxed.rs
+++ b/src/sync/boxed.rs
@@ -1,5 +1,5 @@
 use crate::sync::{Co, Gen};
-use std::{future::Future, pin::Pin};
+use core::{future::Future, pin::Pin};
 
 /// This is a type alias for generators which can be stored in a `'static`. It's
 /// only really needed to help the compiler's type inference along.
@@ -20,7 +20,7 @@ impl<Y, R, C> GenBoxed<Y, R, C> {
     ///
     /// ```compile_fail
     /// # use genawaiter::sync::{Co, Gen, GenBoxed};
-    /// # use std::{future::Future, pin::Pin};
+    /// # use core::{future::Future, pin::Pin};
     /// #
     /// # async fn producer(co: Co<i32>) {
     /// #     for n in (1..).step_by(2).take_while(|&n| n < 10) { co.yield_(n).await; }
@@ -39,11 +39,14 @@ impl<Y, R, C> GenBoxed<Y, R, C> {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use crate::{
         ops::GeneratorState,
         sync::{Co, Gen},
     };
-    use std::sync::{Arc, Mutex};
+    use alloc::sync::Arc;
+    use std::sync::Mutex;
 
     async fn odd_numbers_less_than_ten(mut co: Co<i32>) {
         for n in (1..).step_by(2).take_while(|&n| n < 10) {

--- a/src/sync/boxed.rs
+++ b/src/sync/boxed.rs
@@ -65,7 +65,7 @@ mod tests {
         let _: &dyn Sync = &arc;
 
         let mut guard = arc.lock().unwrap();
-        assert_eq!(guard.resume(), GeneratorState::Yielded(1));
-        assert_eq!(guard.resume(), GeneratorState::Yielded(3));
+        assert_eq!(guard.resume(()), GeneratorState::Yielded(1));
+        assert_eq!(guard.resume(()), GeneratorState::Yielded(3));
     }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1,8 +1,9 @@
+extern crate alloc;
+
 use crate::{core, core::Next};
-use std::{
-    mem,
-    sync::{Arc, Mutex},
-};
+use ::core::mem;
+use alloc::sync::Arc;
+use std::sync::Mutex;
 
 pub struct Airlock<Y, R>(Arc<Mutex<Next<Y, R>>>);
 

--- a/src/sync/generator.rs
+++ b/src/sync/generator.rs
@@ -3,7 +3,7 @@ use crate::{
     ops::{Generator, GeneratorState},
     sync::{engine::Airlock, Co},
 };
-use std::{future::Future, pin::Pin};
+use core::{future::Future, pin::Pin};
 
 /// This is a generator which can be shared between threads.
 ///

--- a/src/sync/iterator.rs
+++ b/src/sync/iterator.rs
@@ -1,5 +1,5 @@
 use crate::{ops::GeneratorState, sync::Gen};
-use std::future::Future;
+use core::future::Future;
 
 impl<Y, F: Future<Output = ()>> IntoIterator for Gen<Y, (), F> {
     type Item = Y;
@@ -29,7 +29,7 @@ impl<Y, F: Future<Output = ()>> Iterator for IntoIter<Y, F> {
 #[cfg(test)]
 mod tests {
     use crate::sync::{Co, Gen};
-    use std::iter::IntoIterator;
+    use core::iter::IntoIterator;
 
     async fn produce(mut co: Co<i32>) {
         co.yield_(10).await;

--- a/src/sync/iterator.rs
+++ b/src/sync/iterator.rs
@@ -19,7 +19,7 @@ impl<Y, F: Future<Output = ()>> Iterator for IntoIter<Y, F> {
     type Item = Y;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.generator.resume() {
+        match self.generator.resume(()) {
             GeneratorState::Yielded(x) => Some(x),
             GeneratorState::Complete(()) => None,
         }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -355,7 +355,7 @@ mod tests {
         GeneratorState,
     };
     use futures::executor::block_on;
-    use std::{
+    use core::{
         cell::{Cell, RefCell},
         future::Future,
     };

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -13,7 +13,7 @@ You can create a basic generator with [`gen!`] and [`yield_!`].
 let mut my_generator = gen!({
     yield_!(10);
 });
-# my_generator.resume();
+# my_generator.resume(());
 # }
 ```
 
@@ -29,7 +29,7 @@ let my_producer = producer!({
     yield_!(10);
 });
 let mut my_generator = Gen::new(my_producer);
-# my_generator.resume();
+# my_generator.resume(());
 # }
 ```
 
@@ -42,7 +42,7 @@ async fn my_producer(mut co: Co<u8>) {
     co.yield_(10).await;
 }
 let mut my_generator = Gen::new(my_producer);
-# my_generator.resume();
+# my_generator.resume(());
 ```
 
 # Storing a generator in a `static`
@@ -134,7 +134,7 @@ let two = 2;
 let mut multiply = gen!({
     yield_!(10 * two);
 });
-assert_eq!(multiply.resume(), GeneratorState::Yielded(20));
+assert_eq!(multiply.resume(()), GeneratorState::Yielded(20));
 # }
 ```
 
@@ -149,12 +149,12 @@ assert_eq!(multiply.resume(), GeneratorState::Yielded(20));
 #     for n in (1..).step_by(2).take_while(|&n| n < 10) { yield_!(n); }
 # });
 #
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(1));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(3));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(5));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(7));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Yielded(9));
-assert_eq!(odds_under_ten.resume(), GeneratorState::Complete(()));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(1));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(3));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(5));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(7));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Yielded(9));
+assert_eq!(odds_under_ten.resume(()), GeneratorState::Complete(()));
 # }
 ```
 
@@ -179,9 +179,9 @@ let mut check_numbers = gen!({
     assert_eq!(num, 2);
 });
 
-check_numbers.resume_with(0);
-check_numbers.resume_with(1);
-check_numbers.resume_with(2);
+check_numbers.resume(0);
+check_numbers.resume(1);
+check_numbers.resume(2);
 # }
 ```
 
@@ -201,9 +201,9 @@ let mut numbers_then_string = gen!({
     "done!"
 });
 
-assert_eq!(numbers_then_string.resume(), GeneratorState::Yielded(10));
-assert_eq!(numbers_then_string.resume(), GeneratorState::Yielded(20));
-assert_eq!(numbers_then_string.resume(), GeneratorState::Complete("done!"));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Yielded(10));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Yielded(20));
+assert_eq!(numbers_then_string.resume(()), GeneratorState::Complete("done!"));
 # }
 ```
 
@@ -220,7 +220,7 @@ async fn produce() {
 }
 
 let mut gen = Gen::new(produce);
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
 # }
 ```
 
@@ -237,7 +237,7 @@ let produce = producer!({
 });
 
 let mut gen = Gen::new(produce);
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
 # }
 ```
 
@@ -271,9 +271,9 @@ let gen = Gen::new(async move |co| {
     co.yield_(10).await;
     co.yield_(20).await;
 });
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Complete(()));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Complete(()));
 ```
 
 ## Using the low-level API with an async <del>closure</del> faux·sure (for stable Rust)
@@ -285,9 +285,9 @@ let mut gen = Gen::new(|mut co| async move {
     co.yield_(10).await;
     co.yield_(20).await;
 });
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Complete(()));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Complete(()));
 ```
 
 ## Using the low-level API with function arguments
@@ -306,9 +306,9 @@ async fn multiples_of(num: i32, mut co: Co<i32>) {
 }
 
 let mut gen = Gen::new(|co| multiples_of(10, co));
-assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-assert_eq!(gen.resume(), GeneratorState::Yielded(30));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+assert_eq!(gen.resume(()), GeneratorState::Yielded(30));
 ```
 */
 
@@ -368,8 +368,8 @@ mod tests {
     #[test]
     fn function() {
         let mut gen = Gen::new(simple_producer);
-        assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
     }
 
     #[test]
@@ -380,8 +380,8 @@ mod tests {
         }
 
         let mut gen = Gen::new(|co| gen(5, co));
-        assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
     }
 
     #[test]
@@ -397,13 +397,13 @@ mod tests {
         let mut gen = Gen::new(|co| gen(&resumes, co));
         assert_eq!(*resumes.borrow(), &[] as &[&str]);
 
-        assert_eq!(gen.resume_with("ignored"), GeneratorState::Yielded(10));
+        assert_eq!(gen.resume("ignored"), GeneratorState::Yielded(10));
         assert_eq!(*resumes.borrow(), &[] as &[&str]);
 
-        assert_eq!(gen.resume_with("abc"), GeneratorState::Yielded(20));
+        assert_eq!(gen.resume("abc"), GeneratorState::Yielded(20));
         assert_eq!(*resumes.borrow(), &["abc"]);
 
-        assert_eq!(gen.resume_with("def"), GeneratorState::Complete(()));
+        assert_eq!(gen.resume("def"), GeneratorState::Complete(()));
         assert_eq!(*resumes.borrow(), &["abc", "def"]);
     }
 
@@ -419,13 +419,13 @@ mod tests {
         async fn run_test() {
             let mut gen = Gen::new(produce);
 
-            let x = gen.async_resume().await;
+            let x = gen.async_resume(()).await;
             assert_eq!(x, GeneratorState::Yielded(10));
 
-            let x = gen.async_resume().await;
+            let x = gen.async_resume(()).await;
             assert_eq!(x, GeneratorState::Yielded(20));
 
-            let x = gen.async_resume().await;
+            let x = gen.async_resume(()).await;
             assert_eq!(x, GeneratorState::Complete(()));
         }
 
@@ -440,7 +440,7 @@ mod tests {
         }
 
         let mut gen = Gen::new(wrong);
-        gen.resume();
+        gen.resume(());
     }
 
     #[test]
@@ -452,7 +452,7 @@ mod tests {
         }
 
         let mut gen = Gen::new(wrong);
-        gen.resume();
+        gen.resume(());
     }
 
     #[test]
@@ -463,7 +463,7 @@ mod tests {
         }
 
         let mut gen = Gen::new(shenanigans);
-        let mut escaped_co = match gen.resume() {
+        let mut escaped_co = match gen.resume(()) {
             GeneratorState::Yielded(_) => panic!(),
             GeneratorState::Complete(co) => co,
         };
@@ -513,15 +513,15 @@ mod tests {
             addrs: &mut Vec<*const i32>,
         ) -> Gen<i32, (), impl Future<Output = &'static str> + '_> {
             let mut gen = Gen::new(move |co| produce(addrs, co));
-            assert_eq!(gen.resume(), GeneratorState::Yielded(10));
+            assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
             gen
         }
 
         let mut addrs = Vec::new();
         let mut gen = create_generator(&mut addrs);
 
-        assert_eq!(gen.resume(), GeneratorState::Yielded(20));
-        assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+        assert_eq!(gen.resume(()), GeneratorState::Yielded(20));
+        assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
         drop(gen);
 
         assert!(addrs.iter().all(|&p| p == addrs[0]));

--- a/src/sync/nightly_tests.rs
+++ b/src/sync/nightly_tests.rs
@@ -9,6 +9,6 @@ fn async_closure() {
         co.yield_(10).await;
         "done"
     });
-    assert_eq!(gen.resume(), GeneratorState::Yielded(10));
-    assert_eq!(gen.resume(), GeneratorState::Complete("done"));
+    assert_eq!(gen.resume(()), GeneratorState::Yielded(10));
+    assert_eq!(gen.resume(()), GeneratorState::Complete("done"));
 }

--- a/src/sync/stream.rs
+++ b/src/sync/stream.rs
@@ -12,7 +12,7 @@ impl<Y, F: Future<Output = ()>> Stream for Gen<Y, (), F> {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        let fut = self.async_resume();
+        let fut = self.async_resume(());
         pin_mut!(fut);
         match fut.poll(cx) {
             Poll::Ready(GeneratorState::Yielded(x)) => Poll::Ready(Some(x)),

--- a/src/sync/stream.rs
+++ b/src/sync/stream.rs
@@ -3,7 +3,7 @@ use futures_core::{
     task::{Context, Poll},
     Stream,
 };
-use std::{future::Future, pin::Pin};
+use core::{future::Future, pin::Pin};
 
 impl<Y, F: Future<Output = ()>> Stream for Gen<Y, (), F> {
     type Item = Y;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     ptr,
     task::{RawWaker, RawWakerVTable, Waker},
 };

--- a/tests/rc.rs
+++ b/tests/rc.rs
@@ -125,7 +125,7 @@ fn rc_convenience_macro_resume() {
         assert_eq!(resume_arg, "def");
     });
 
-    assert_eq!(gen.resume_with("ignored"), GeneratorState::Yielded(10));
-    assert_eq!(gen.resume_with("abc"), GeneratorState::Yielded(20));
-    assert_eq!(gen.resume_with("def"), GeneratorState::Complete(()));
+    assert_eq!(gen.resume("ignored"), GeneratorState::Yielded(10));
+    assert_eq!(gen.resume("abc"), GeneratorState::Yielded(20));
+    assert_eq!(gen.resume("def"), GeneratorState::Complete(()));
 }

--- a/tests/stack.rs
+++ b/tests/stack.rs
@@ -186,7 +186,7 @@ fn stack_convenience_macro_resume() {
         assert_eq!(resume_arg, "def");
     });
 
-    assert_eq!(gen.resume_with("ignored"), GeneratorState::Yielded(10));
-    assert_eq!(gen.resume_with("abc"), GeneratorState::Yielded(20));
-    assert_eq!(gen.resume_with("def"), GeneratorState::Complete(()));
+    assert_eq!(gen.resume("ignored"), GeneratorState::Yielded(10));
+    assert_eq!(gen.resume("abc"), GeneratorState::Yielded(20));
+    assert_eq!(gen.resume("def"), GeneratorState::Complete(()));
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -111,7 +111,7 @@ fn sync_convenience_macro_resume() {
         assert_eq!(resume_arg, "def");
     });
 
-    assert_eq!(gen.resume_with("ignored"), GeneratorState::Yielded(10));
-    assert_eq!(gen.resume_with("abc"), GeneratorState::Yielded(20));
-    assert_eq!(gen.resume_with("def"), GeneratorState::Complete(()));
+    assert_eq!(gen.resume("ignored"), GeneratorState::Yielded(10));
+    assert_eq!(gen.resume("abc"), GeneratorState::Yielded(20));
+    assert_eq!(gen.resume("def"), GeneratorState::Complete(()));
 }

--- a/tests/ui/rc_fail_not_awaiting_yield.stderr
+++ b/tests/ui/rc_fail_not_awaiting_yield.stderr
@@ -2,8 +2,8 @@ error[E0499]: cannot borrow `co` as mutable more than once at a time
  --> $DIR/rc_fail_not_awaiting_yield.rs:6:15
   |
 5 |     let foo = co.yield_(10);
-  |               -- first mutable borrow occurs here
+  |               ------------- first mutable borrow occurs here
 6 |     let bar = co.yield_(20);
-  |               ^^ second mutable borrow occurs here
+  |               ^^^^^^^^^^^^^ second mutable borrow occurs here
 7 | }
-  | - first borrow might be used here, when `foo` is dropped and runs the destructor for type `impl std::future::Future`
+  | - first borrow might be used here, when `foo` is dropped and runs the destructor for type `impl Future<Output = <genawaiter::rc::engine::Airlock<i32, ()> as genawaiter::core::Airlock>::Resume>`

--- a/tests/ui/stack_fail_not_awaiting_yield.stderr
+++ b/tests/ui/stack_fail_not_awaiting_yield.stderr
@@ -3,3 +3,15 @@ error[E0726]: implicit elided lifetime not allowed here
   |
 4 | async fn wrong(mut co: Co<i32>) {
   |                        ^^^^^^^ help: indicate the anonymous lifetime: `Co<'_, i32>`
+  |
+  = note: assuming a `'static` lifetime...
+
+error[E0499]: cannot borrow `co` as mutable more than once at a time
+ --> $DIR/stack_fail_not_awaiting_yield.rs:6:15
+  |
+5 |     let foo = co.yield_(10);
+  |               ------------- first mutable borrow occurs here
+6 |     let bar = co.yield_(20);
+  |               ^^^^^^^^^^^^^ second mutable borrow occurs here
+7 | }
+  | - first borrow might be used here, when `foo` is dropped and runs the destructor for type `impl Future<Output = <&stack::engine::Airlock<i32, ()> as genawaiter::core::Airlock>::Resume>`

--- a/tests/ui/stack_fail_when_co_is_static.stderr
+++ b/tests/ui/stack_fail_when_co_is_static.stderr
@@ -2,7 +2,7 @@ error[E0597]: `shelf` does not live long enough
   --> $DIR/stack_fail_when_co_is_static.rs:8:5
    |
 8  |     let_gen_using!(gen, producer);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     borrowed value does not live long enough
    |     argument requires that `shelf` is borrowed for `'static`
@@ -10,4 +10,4 @@ error[E0597]: `shelf` does not live long enough
 10 | }
    | - `shelf` dropped here while still borrowed
    |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+   = note: this error originates in the macro `let_gen_using` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/sync_fail_not_awaiting_yield.stderr
+++ b/tests/ui/sync_fail_not_awaiting_yield.stderr
@@ -2,8 +2,8 @@ error[E0499]: cannot borrow `co` as mutable more than once at a time
  --> $DIR/sync_fail_not_awaiting_yield.rs:6:15
   |
 5 |     let foo = co.yield_(10);
-  |               -- first mutable borrow occurs here
+  |               ------------- first mutable borrow occurs here
 6 |     let bar = co.yield_(20);
-  |               ^^ second mutable borrow occurs here
+  |               ^^^^^^^^^^^^^ second mutable borrow occurs here
 7 | }
-  | - first borrow might be used here, when `foo` is dropped and runs the destructor for type `impl std::future::Future`
+  | - first borrow might be used here, when `foo` is dropped and runs the destructor for type `impl Future<Output = <genawaiter::sync::engine::Airlock<i32, ()> as genawaiter::core::Airlock>::Resume>`


### PR DESCRIPTION
I'd like to use this crate in an embedded environment, so I've gone through and replaced all referenced to `std` with `core` except for `alloc::sync::Arc` which is required for the `rc` and `sync` engines and `std::sync::Mutex` which is required for the `sync` engine alone.

Also, now that nightly's `Generator` has been updated to take an argument, the custom `Coroutine` trait isn't required; I've removed it in favor of the base `Generator` trait.

(These could be split into single-purpose PRs easily if that would be preferable.)